### PR TITLE
MINOR: keeping writing consistent 'Instanciator' -> 'Instantiator'

### DIFF
--- a/tests/PuphpeteerTest.php
+++ b/tests/PuphpeteerTest.php
@@ -127,10 +127,10 @@ class PuphpeteerTest extends TestCase
     public function check_all_resources_are_supported()
     {
         $incompleteResources = [];
-        $resourceInstanciator = new ResourceInstanciator($this->browserOptions, $this->url);
+        $resourceInstantiator = new ResourceInstantiator($this->browserOptions, $this->url);
 
-        foreach ($resourceInstanciator->getResourceNames() as $name) {
-            $resource = $resourceInstanciator->{$name}(new Puppeteer, $this->browserOptions);
+        foreach ($resourceInstantiator->getResourceNames() as $name) {
+            $resource = $resourceInstantiator->{$name}(new Puppeteer, $this->browserOptions);
 
             if ($resource instanceof UntestableResource) {
                 $incompleteResources[$name] = $resource;

--- a/tests/ResourceInstantiator.php
+++ b/tests/ResourceInstantiator.php
@@ -4,7 +4,7 @@ namespace Nesk\Puphpeteer\Tests;
 
 use Nesk\Rialto\Data\JsFunction;
 
-class ResourceInstanciator
+class ResourceInstantiator
 {
     protected $resources = [];
 


### PR DESCRIPTION
Hey @nesk 

catching up on the small things I've noticed: Here keeping the writing consistent with the previously merged PR ('Instanciator' -> 'Instantiator'). I'm not a native speaker and would have written it with c too, so just following Google' statement and consistency 👍️

Cheers,
Peter