### PR TITLE
Drop 7.1 support, add 7.4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [7.1, 7.2, 7.3]
+        php-version: [7.2, 7.3, 7.4]
         composer-flags: [null, --prefer-lowest]
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Composer Version](https://img.shields.io/packagist/v/nesk/puphpeteer.svg?style=flat-square&label=Composer)](https://packagist.org/packages/nesk/puphpeteer)
 [![Node Version](https://img.shields.io/node/v/@nesk/puphpeteer.svg?style=flat-square&label=Node)](https://nodejs.org/)
 [![NPM Version](https://img.shields.io/npm/v/@nesk/puphpeteer.svg?style=flat-square&label=NPM)](https://www.npmjs.com/package/@nesk/puphpeteer)
-[![Build Status](https://img.shields.io/travis/nesk/puphpeteer.svg?style=flat-square&label=Build%20Status)](https://travis-ci.org/nesk/puphpeteer)
+[![Build Status](https://img.shields.io/github/workflow/status/rialto-php/puphpeteer/phpunit?style=flat-square&label=Build%20Status)](https://github.com/rialto-php/puphpeteer/actions)
 
 >PuPHPeteer is searching for a new maintainer, I don't have time or motivation to maintain this project anymore. Please [contact me](https://github.com/nesk) if you're interested.
 
@@ -57,7 +57,7 @@ $browser->close();
 
 ## Requirements and installation
 
-This package requires PHP >= 7.1 and Node >= 8.
+This package requires PHP >= 7.2 and Node >= 8.
 
 Install it with these two command lines:
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "nesk/rialto": "^1.2.0",
         "psr/log": "^1.0",
         "vierbergenlars/php-semver": "^3.0.2"


### PR DESCRIPTION
Hey @nesk 

I would suggest to drop 7.1 (not supported anymore) and add 7.4 instead. What's your take on this? 

Includes an fix of the badge in the README - not sure why it doesn't show proper tho, any ideas?

Cheers,
Peter