### PR TITLE
Feat: support for puppeteer-extra plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ try {
 
 Instead, a `Node\Exception` will be thrown, the Node process will stay alive and usable.
 
+### Puppeteer plugins
+
+To use puppeteer-extra plugins add them to your project:
+```shell
+npm install puppeteer puppeteer-extra puppeteer-extra-plugin-stealth
+```
+
+Then override js inclusion with js_extra option
+```php
+    $puppeteer = new Puppeteer([
+        'js_extra' => /** @lang JavaScript */ "
+            const puppeteer = require('puppeteer-extra');
+            const StealthPlugin = require('puppeteer-extra-plugin-stealth');
+            puppeteer.use(StealthPlugin());
+            instruction.setDefaultResource(puppeteer);
+        "
+    ]);
+```
+
+
+
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE) for more information.

--- a/src/Puppeteer.php
+++ b/src/Puppeteer.php
@@ -28,6 +28,9 @@ class Puppeteer extends AbstractEntryPoint
 
         // Logs the output of Browser's console methods (console.log, console.debug, etc...) to the PHP logger
         'log_browser_console' => false,
+
+        //Custom js to load puppeteer-extra plugins
+        'js_extra' => ''
     ];
 
     /**

--- a/src/PuppeteerConnectionDelegate.js
+++ b/src/PuppeteerConnectionDelegate.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const puppeteer = require('puppeteer'),
-    {ConnectionDelegate} = require('@nesk/rialto'),
+const {ConnectionDelegate} = require('@nesk/rialto'),
     Logger = require('@nesk/rialto/src/node-process/Logger'),
     ConsoleInterceptor = require('@nesk/rialto/src/node-process/NodeInterceptors/ConsoleInterceptor'),
     StandardStreamsInterceptor = require('@nesk/rialto/src/node-process/NodeInterceptors/StandardStreamsInterceptor');
@@ -28,7 +27,12 @@ class PuppeteerConnectionDelegate extends ConnectionDelegate
      * @inheritdoc
      */
     async handleInstruction(instruction, responseHandler, errorHandler) {
-        instruction.setDefaultResource(puppeteer);
+        if (this.options.js_extra) {
+            eval(this.options.js_extra);
+        } else {
+            const puppeteer = require('puppeteer');
+            instruction.setDefaultResource(puppeteer);
+        }
 
         let value = null;
 


### PR DESCRIPTION
Corresponding issue: https://github.com/rialto-php/puphpeteer/issues/67

Added new option to allow override puppeteer instance.

This is example usage of [puppeteer-extra-plugin-stealth](https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth): 

```php
<?php
require "vendor/autoload.php";

use Nesk\Puphpeteer\Puppeteer;

$puppeteer = new Puppeteer([
    'js_extra' => /** @lang JavaScript */ "
        const puppeteer = require('puppeteer-extra');
        const StealthPlugin = require('puppeteer-extra-plugin-stealth');
        puppeteer.use(StealthPlugin());
        instruction.setDefaultResource(puppeteer);
    ",
]);
$browser = $puppeteer->launch();

$page = $browser->newPage();

$page->goto('https://bot.sannysoft.com');
$page->waitForTimeout(5000);
$page->screenshot(['path' => 'example2.png', 'fullPage'=> true]);

$browser->close();
```

Without plugin: 
![example2](https://user-images.githubusercontent.com/34161928/129078971-1346cfa4-cc82-4cbc-b0f1-53a4e86ef54f.png)

With plugin (code above): 
![example](https://user-images.githubusercontent.com/34161928/129078940-bdeb8dbb-3447-4494-b776-986fa465eb19.png)
