### PR TITLE
Use v10 of puppeteer to support M1 Macs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@nesk/rialto": "^1.2.1",
-    "puppeteer": "~5.5.0"
+    "puppeteer": "^10"
   },
   "devDependencies": {
     "@types/yargs": "^15.0.10",


### PR DESCRIPTION
Before v10 the installation couldn't be completed because the chromium binary couldn't be found for arm which causes the following error on installation: `The chromium binary is not available for arm64`

Not sure if this will cause other problems, but everything i'm running with this package is still working without any problems.